### PR TITLE
add userId to  user profile schema

### DIFF
--- a/src/api/schemas/user.ts
+++ b/src/api/schemas/user.ts
@@ -24,6 +24,7 @@ export const userInfoSchema = {
 export const userProfileSchema = {
   type: 'object',
   properties: {
+    id: {type: 'string'},
     ...properties,
     profile: {
       nullable: true,


### PR DESCRIPTION
when we try get 
/users/my/students?search="Yofri"
there's no userId in the response.
userId will be used to create teams.

```
[
    {
        "name": "Yofriadi Yahya",
        "email": "yofriadi.yahya@markoding.com",
        "profile": {
            "id": "a8a23eb3-60eb-4361-ac7d-d32e2020d9f5",
            "createdAt": "2021-01-06T04:48:45.434Z",
            "updatedAt": "2021-01-06T04:48:45.434Z",
            "deletedAt": "",
            "profileType": "student",
            "schoolId": "ckfgnmbwq2d5m0766462893sy",
            "schoolName": "SMA AL-KAUTSAR",
            "schoolTypeId": "ckfgf815j4nr10766fky05vy2",
            "schoolTypeName": "Negeri",
            "schoolGradeId": "ckfgf80wx4nqg0766kchm3ukx",
            "schoolGradeName": "SMA",
            "classId": "",
            "className": "",
            "cityId": "ckdrhj6crd6nj0768tgdw5s50",
            "cityName": "Kota Adm. Jakarta Selatan",
            "provinceId": "ckdrhj6cpd6ne07687g59ulc2",
            "provinceName": "DKI Jakarta",
            "workingPosition": "",
            "companyName": "",
            "expertise": "",
            "startTeachingYear": 0,
            "lastEducationGradeId": "",
            "lastEducationGradeName": ""
        }
    }
]
```